### PR TITLE
New i2c commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Since there is one source and two header files they can be built also just as
 normal source files.
 
 There are 2 basic types of i2c communications to implement:
-1. Block read - this function is used for all data read-outs, including a signle
+1. Block read - this function is used for all data read-outs, including a single
 word read-out. For more information please refer to the datasheet chapter regarding
 the communication protocol
 2. Block write - the function needs to send selectable number of bytes. 
 This function is used for the device configurations such as 
 refresh rate, measurement mode, output format, emissivity background temperature,
-i2c settings, etc and for the device commands such as reset, force start/sync,
+i2c settings, etc. and for the device commands such as reset, force start/sync,
 goto sleep and wake-up. For more information please refer to the datasheet chapter regarding
 the user configurable options.
 
@@ -67,7 +67,7 @@ After the environment is set you need to enter below flow to your program.
 int main(void)
 {
     int status = 0; /**< Variable will store return values */
-    uint16_t mlxto[MLX90642_TOTAL_NUMBER_OF_PIXELS + 1]; /**< Image data in degC*50 or normalized depending on the output format congifuration */
+    int16_t mlxto[MLX90642_TOTAL_NUMBER_OF_PIXELS + 1]; /**< Image data in degC*50 or normalized depending on the output format congifuration */
     
     /* Initialize the MLX90642 device - Prepare a clean start - start or sync a new measurement and wait for the data to be available for reading */
     status = MLX90642_Init(SA_90642);
@@ -108,7 +108,7 @@ After the environment is set you need to enter one of the below flows to your pr
 int main(void)
 {
     int status = 0; /**< Variable will store return values */
-    uint16_t mlxto[MLX90642_TOTAL_NUMBER_OF_PIXELS + 1]; /**< Image data in degC*50 or normalized depending on the output format congifuration */
+    int16_t mlxto[MLX90642_TOTAL_NUMBER_OF_PIXELS + 1]; /**< Image data in degC*50 or normalized depending on the output format congifuration */
     
     /* Initialize the MLX90642 device - Prepare a clean start - start or sync a new measurement and wait for the data to be available for reading */
     status = MLX90642_Init(SA_90642);
@@ -137,7 +137,7 @@ int main(void)
 int main(void)
 {
     int status = 0; /**< Variable will store return values */
-    uint16_t mlxto[MLX90642_TOTAL_NUMBER_OF_PIXELS + 1]; /**< Image data in degC*50 or normalized depending on the output format congifuration */
+    int16_t mlxto[MLX90642_TOTAL_NUMBER_OF_PIXELS + 1]; /**< Image data in degC*50 or normalized depending on the output format congifuration */
     
     /* Initialize the MLX90642 device - Prepare a clean start - start or sync a new measurement and wait for the data to be available for reading */
     status = MLX90642_Init(SA_90642);

--- a/README.md
+++ b/README.md
@@ -11,16 +11,12 @@ There are 4 types of i2c communications to implement:
 1. Block read - this function is used for all data read-outs, including a signle
 word read-out. For more information please refer to the datasheet chapter regarding
 the communication protocol
-2. Configuration - this function is used for the device configurations such as 
+2. Block write - the function needs to send selectable number of bytes. 
+This function is used for the device configurations such as 
 refresh rate, measurement mode, output format, emissivity background temperature,
-i2c settings, etc. For more information please refer to the datasheet chapter regarding
+i2c settings, etc and for the device commands such as reset, force start/sync,
+goto sleep and wake-up. For more information please refer to the datasheet chapter regarding
 the user configurable options.
-3. Command - this function is used for sending commands such as reset, goto sleep,
-force start/sync. For more information please refer to the datasheet chapter regarding
-the communication protocol
-4. Wake up - this function is used to get the device out of sleep mode.
-For more information please refer to the datasheet chapter regarding
-the communication protocol
 
 The driver functions may also use a wait function. That funbction is also included
 in the MLX90642_depends.h file and needs to be implemented individually for a given MCU. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ in `MLX90642_depends.h` file.
 Since there is one source and two header files they can be built also just as
 normal source files.
 
-There are 4 types of i2c communications to implement:
+There are 2 basic types of i2c communications to implement:
 1. Block read - this function is used for all data read-outs, including a signle
 word read-out. For more information please refer to the datasheet chapter regarding
 the communication protocol

--- a/inc/MLX90642.h
+++ b/inc/MLX90642.h
@@ -1,5 +1,5 @@
 /**
- * @copyright (C) 2017 Melexis N.V.
+ * @copyright (C) 2025 Melexis N.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  *
  */
 
-#include <MLX90642_depends.h>
-
 #ifndef _MLX90642_H_
 #define _MLX90642_H_
+
+#include "MLX90642_depends.h"
 
 #define MLX90642_NACK_ERR 1
 #define MLX90642_INVAL_VAL_ERR 2
@@ -103,9 +103,47 @@
 #define MLX90642_ADRESSED_RESET_CMD 0x0006
 #define MLX90642_START_SYNC_MEAS_CMD 0x0001
 #define MLX90642_SLEEP_CMD 0x0007
+#define MLX90642_WAKE_CMD 0x57
 
 #define MLX90642_MS_BYTE(reg)   (reg >> 8)
 #define MLX90642_LS_BYTE(reg)   (reg & 0x00FF)
+
+#define MLX90642_I2C_CONFIG_BYTES_NUM 6
+#define MLX90642_I2C_CMD_BYTES_NUM 4
+#define MLX90642_I2C_WAKEUP_BYTES_NUM 1
+
+/** MLX90642 configuration I2C command
+ * @note For more information refer to the MLX90642 datasheet
+ *
+ * @param[in] slaveAddr I2C slave address of the device
+ * @param[in] writeAddress Configuration address to write to
+ * @param[in] wData Data to write
+ *
+ * @retval  <0 Error while configuring the MLX90642 device
+ *
+ */
+int MLX90642_Config(uint8_t slaveAddr, uint16_t writeAddress, uint16_t wData);
+
+/** MLX90642 I2C commands send
+ * @note The addressed reset, start/sync measurement and sleep commands share the same I2C format. For more information refer to the MLX90642 datasheet
+ *
+ * @param[in] slaveAddr I2C slave address of the device
+ * @param[in] i2c_cmd MLX90642 I2C command to send
+ *
+ * @retval  <0 Error while sending the I2C command to the MLX90642 device
+ *
+ */
+int MLX90642_I2CCmd(uint8_t slaveAddr, uint16_t i2c_cmd);
+
+/** MLX90642 wake-up command
+ * @note For more information refer to the MLX90642 datasheet
+ *
+ * @param[in] slaveAddr I2C slave address of the device
+ *
+ * @retval  <0 Error while sending the wake-up command to the MLX90642 device
+ *
+ */
+int MLX90642_WakeUp(uint8_t slaveAddr);
 
 /** Get the ID of the MLX90642 device
  *
@@ -117,16 +155,18 @@
  */
 int MLX90642_GetID(uint8_t slaveAddr, uint16_t *mlxid);
 
-/** Get the firmware version of the MLX90642 device
+/** Get the firmware semantic version of the MLX90642 device
  * @note Different version of the FW may support different features
  *
  * @param[in] slaveAddr I2C slave address of the device
- * @param[out] fwver Pointer to where the firmware versioin is stored
+ * @param[out] major Pointer to where the Major is stored
+ * @param[out] minor Pointer to where the Minor is stored
+ * @param[out] patch Pointer to where the Patch is stored
  *
  * @retval <0 Error while reading the firmware version
  *
  */
-int MLX90642_GetFWver(uint8_t slaveAddr, uint8_t *fwver);
+int MLX90642_GetFWver(uint8_t slaveAddr, uint8_t *major, uint8_t *minor, uint8_t *patch);
 
 /** Get the measurement mode of the MLX90642 device
  *
@@ -410,7 +450,7 @@ int MLX90642_StartSync(uint8_t slaveAddr);
  * @retval <0 Error while runnning the new measurement
  *
  */
-int MLX90642_MeasureNow(uint8_t slaveAddr, uint16_t *pixVal);
+int MLX90642_MeasureNow(uint8_t slaveAddr, int16_t *pixVal);
 
 /** Get the calculated image from the MLX90642 device
  * @note The image will contain temperature data or normalized data depending on the output format set
@@ -422,7 +462,7 @@ int MLX90642_MeasureNow(uint8_t slaveAddr, uint16_t *pixVal);
  * @retval <0 Error while getting the image
  *
  */
-int MLX90642_GetImage(uint8_t slaveAddr, uint16_t *pixVal);
+int MLX90642_GetImage(uint8_t slaveAddr, int16_t *pixVal);
 
 /** Get the full frame data - raw IR data, aux data and calculated image from the MLX90642 device
  * @note The image will contain temperature data or normalized data depending on the output format set
@@ -436,7 +476,7 @@ int MLX90642_GetImage(uint8_t slaveAddr, uint16_t *pixVal);
  * @retval <0 Error while getting the full frame data
  *
  */
-int MLX90642_GetFrameData(uint8_t slaveAddr, uint16_t *aux, uint16_t *rawpix, uint16_t *pixVal);
+int MLX90642_GetFrameData(uint8_t slaveAddr, uint16_t *aux, uint16_t *rawpix, int16_t *pixVal);
 
 /** Puts the MLX90642 device in low power consumption mode
  *

--- a/inc/MLX90642.h
+++ b/inc/MLX90642.h
@@ -466,6 +466,7 @@ int MLX90642_GetImage(uint8_t slaveAddr, int16_t *pixVal);
 
 /** Get the full frame data - raw IR data, aux data and calculated image from the MLX90642 device
  * @note The image will contain temperature data or normalized data depending on the output format set
+ * @note The pixVal buffer is also used to store the Ta value. Thus its size must be the number of pixels + 1
  *
  * @param[in] slaveAddr I2C slave address of the device
  * @param[out] aux Pointer to where the aux data is stored

--- a/inc/MLX90642_depends.h
+++ b/inc/MLX90642_depends.h
@@ -1,5 +1,5 @@
 /**
- * @copyright (C) 2017 Melexis N.V.
+ * @copyright (C) 2025 Melexis N.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,38 +33,18 @@
 
 int MLX90642_I2CRead(uint8_t slaveAddr, uint16_t startAddress, uint16_t nMemAddressRead, uint16_t *rData);
 
-/** MLX90642 configuration I2C command
- * @note For more information refer to the MLX90642 datasheet
+/** MLX90642 block write I2C command
+ * @note Sends multiple bytes on the I2C bus. This function is used by te Config, Command, Sleep and Wake-up functions
  *
  * @param[in] slaveAddr I2C slave address of the device
- * @param[in] writeAddress Configuration address to write to
- * @param[in] wData Data to write
+ * @param[in] buffer Pointer to the buffer that contains the data to send
+ * @param[in] bytesNum Number of bytes to send
  *
- * @retval  <0 Error while configuring the MLX90642 device
+ * @retval  <0 Error while sending the data
  *
  */
-int MLX90642_Config(uint8_t slaveAddr, uint16_t writeAddress, uint16_t wData);
 
-/** MLX90642 I2C commands send
- * @note The addressed reset, start/sync measurement and sleep commands ahsre the same I2C format. For more information refer to the MLX90642 datasheet
- *
- * @param[in] slaveAddr I2C slave address of the device
- * @param[in] i2c_cmd MLX90642 I2C command to send
- *
- * @retval  <0 Error while sending the I2C command to the MLX90642 device
- *
- */
-int MLX90642_I2CCmd(uint8_t slaveAddr, uint16_t i2c_cmd);
-
-/** MLX90642 wake-up command
- * @note For more information refer to the MLX90642 datasheet
- *
- * @param[in] slaveAddr I2C slave address of the device
- *
- * @retval  <0 Error while sending the wake-up command to the MLX90642 device
- *
- */
-int MLX90642_WakeUp(uint8_t slaveAddr);
+int MLX90642_I2CWrite(uint8_t slaveAddr, uint8_t *buffer, uint8_t bytesNum);
 
 /** Delay function
  *

--- a/inc/MLX90642_depends.h
+++ b/inc/MLX90642_depends.h
@@ -34,7 +34,7 @@
 int MLX90642_I2CRead(uint8_t slaveAddr, uint16_t startAddress, uint16_t nMemAddressRead, uint16_t *rData);
 
 /** MLX90642 block write I2C command
- * @note Sends multiple bytes on the I2C bus. This function is used by te Config, Command, Sleep and Wake-up functions
+ * @note Sends multiple bytes on the I2C bus. This function is used by the Config, Command, Sleep and Wake-up functions
  *
  * @param[in] slaveAddr I2C slave address of the device
  * @param[in] buffer Pointer to the buffer that contains the data to send
@@ -44,7 +44,7 @@ int MLX90642_I2CRead(uint8_t slaveAddr, uint16_t startAddress, uint16_t nMemAddr
  *
  */
 
-int MLX90642_I2CWrite(uint8_t slaveAddr, uint8_t *buffer, uint8_t bytesNum);
+int MLX90642_I2CWrite(uint8_t slaveAddr, const uint8_t *buffer, uint8_t bytesNum);
 
 /** Delay function
  *

--- a/src/MLX90642.c
+++ b/src/MLX90642.c
@@ -1,5 +1,5 @@
 /**
- * @copyright (C) 2017 Melexis N.V.
+ * @copyright (C) 2025 Melexis N.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,37 @@
  * limitations under the License.
  *
  */
-#include <MLX90642_depends.h>
-#include <MLX90642.h>
+#include "MLX90642_depends.h"
+#include "MLX90642.h"
+
+int MLX90642_Config(uint8_t slaveAddr, uint16_t writeAddress, uint16_t data)
+{
+    uint8_t wr_buf[MLX90642_I2C_CONFIG_BYTES_NUM];
+
+    wr_buf[0] = MLX90642_MS_BYTE(MLX90642_CONFIG_OPCODE);
+    wr_buf[1] = MLX90642_LS_BYTE(MLX90642_CONFIG_OPCODE);
+    wr_buf[2] = MLX90642_MS_BYTE(writeAddress);
+    wr_buf[3] = MLX90642_LS_BYTE(writeAddress);
+    wr_buf[4] = MLX90642_MS_BYTE(data);
+    wr_buf[5] = MLX90642_LS_BYTE(data);
+
+    return MLX90642_I2CWrite(slaveAddr, wr_buf, MLX90642_I2C_CONFIG_BYTES_NUM);
+
+}
+
+int MLX90642_I2CCmd(uint8_t slaveAddr, uint16_t i2c_cmd)
+{
+
+    uint8_t wr_buf[MLX90642_I2C_CMD_BYTES_NUM];
+
+    wr_buf[0] = MLX90642_MS_BYTE(MLX90642_CMD_OPCODE);
+    wr_buf[1] = MLX90642_LS_BYTE(MLX90642_CMD_OPCODE);;
+    wr_buf[2] = MLX90642_MS_BYTE(i2c_cmd);
+    wr_buf[3] = MLX90642_LS_BYTE(i2c_cmd);
+
+    return MLX90642_I2CWrite(slaveAddr, wr_buf, MLX90642_I2C_CMD_BYTES_NUM);
+
+}
 
 int MLX90642_GetID(uint8_t slaveAddr, uint16_t *mlxid)
 {
@@ -24,15 +53,15 @@ int MLX90642_GetID(uint8_t slaveAddr, uint16_t *mlxid)
 
 }
 
-int MLX90642_GetFWver(uint8_t slaveAddr, uint8_t *fwver)
+int MLX90642_GetFWver(uint8_t slaveAddr, uint8_t *major, uint8_t *minor, uint8_t *patch)
 {
 
     uint16_t data[2];
     int status = MLX90642_I2CRead(slaveAddr, MLX90642_FW_VER_ADDRESS1, MLX90642_NUMBER_OF_FWVER_WORDS, data);
 
-    fwver[0] = MLX90642_MS_BYTE(data[0]);
-    fwver[1] = MLX90642_LS_BYTE(data[1]);
-    fwver[2] = MLX90642_MS_BYTE(data[1]);
+    *major = MLX90642_MS_BYTE(data[0]);
+    *minor = MLX90642_LS_BYTE(data[1]);
+    *patch = MLX90642_MS_BYTE(data[1]);
 
     return status;
 }
@@ -445,7 +474,7 @@ int MLX90642_StartSync(uint8_t slaveAddr)
 
 }
 
-int MLX90642_MeasureNow(uint8_t slaveAddr, uint16_t *pixVal)
+int MLX90642_MeasureNow(uint8_t slaveAddr, int16_t *pixVal)
 {
 
     uint16_t ref_time;
@@ -488,14 +517,14 @@ int MLX90642_MeasureNow(uint8_t slaveAddr, uint16_t *pixVal)
 
 }
 
-int MLX90642_GetImage(uint8_t slaveAddr, uint16_t *pixVal)
+int MLX90642_GetImage(uint8_t slaveAddr, int16_t *pixVal)
 {
 
-    return MLX90642_I2CRead(slaveAddr, MLX90642_TO_DATA_ADDRESS, MLX90642_TOTAL_NUMBER_OF_PIXELS, pixVal);
+    return MLX90642_I2CRead(slaveAddr, MLX90642_TO_DATA_ADDRESS, MLX90642_TOTAL_NUMBER_OF_PIXELS, (uint16_t *) pixVal);
 
 }
 
-int MLX90642_GetFrameData(uint8_t slaveAddr, uint16_t *aux, uint16_t *rawpix, uint16_t *pixVal)
+int MLX90642_GetFrameData(uint8_t slaveAddr, uint16_t *aux, uint16_t *rawpix, int16_t *pixVal)
 {
 
     int status;
@@ -508,7 +537,10 @@ int MLX90642_GetFrameData(uint8_t slaveAddr, uint16_t *aux, uint16_t *rawpix, ui
     if(status < 0)
         return status;
 
-    status = MLX90642_I2CRead(slaveAddr, MLX90642_TO_DATA_ADDRESS, MLX90642_TOTAL_NUMBER_OF_PIXELS + 1, pixVal);
+    status = MLX90642_I2CRead(slaveAddr,
+                              MLX90642_TO_DATA_ADDRESS,
+                              MLX90642_TOTAL_NUMBER_OF_PIXELS + 1,
+                              (uint16_t *)pixVal);
 
     return status;
 
@@ -518,5 +550,15 @@ int MLX90642_GotoSleep(uint8_t slaveAddr)
 {
 
     return MLX90642_I2CCmd(slaveAddr, MLX90642_SLEEP_CMD);
+
+}
+
+int MLX90642_WakeUp(uint8_t slaveAddr)
+{
+    uint8_t wr_buf[MLX90642_I2C_WAKEUP_BYTES_NUM];
+
+    wr_buf[0] = MLX90642_WAKE_CMD;
+
+    return MLX90642_I2CWrite(slaveAddr, wr_buf, MLX90642_I2C_WAKEUP_BYTES_NUM);
 
 }

--- a/src/MLX90642.c
+++ b/src/MLX90642.c
@@ -38,7 +38,7 @@ int MLX90642_I2CCmd(uint8_t slaveAddr, uint16_t i2c_cmd)
     uint8_t wr_buf[MLX90642_I2C_CMD_BYTES_NUM];
 
     wr_buf[0] = MLX90642_MS_BYTE(MLX90642_CMD_OPCODE);
-    wr_buf[1] = MLX90642_LS_BYTE(MLX90642_CMD_OPCODE);;
+    wr_buf[1] = MLX90642_LS_BYTE(MLX90642_CMD_OPCODE);
     wr_buf[2] = MLX90642_MS_BYTE(i2c_cmd);
     wr_buf[3] = MLX90642_LS_BYTE(i2c_cmd);
 


### PR DESCRIPTION
Simplify the I2C dependencies reducing them to only byte read and byte write

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device configuration, command sending and wake-up capabilities via block write operations.

* **Refactor**
  * Firmware version now reported as separate major/minor/patch values.
  * Measurement data outputs changed to signed 16-bit values.

* **Documentation**
  * README clarifies I2C protocol now described as two types (block read / block write).
  * Example buffers updated to use signed 16-bit types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->